### PR TITLE
Actualiza main para leer lista de requerimientos

### DIFF
--- a/agentic_architect/main.py
+++ b/agentic_architect/main.py
@@ -16,16 +16,16 @@ def configure_logging() -> None:
     )
 
 
-def run(config_path: str) -> None:
+def run(config_path: str, req_path: str = "requerimientos.txt") -> None:
     logger = logging.getLogger(__name__)
 
     cfg = Config.load(config_path)
     logger.info("Configuration loaded from %s", config_path)
 
-    with open("requerimiento.txt", "r") as f:
+    with open(req_path, "r") as f:
         requirements = [line.strip() for line in f if line.strip()]
 
-    print(requirements)
+    logger.info("Loaded %d requirements from %s", len(requirements), req_path)
 
     llm = connector_from_config(cfg.llm)
 
@@ -41,17 +41,23 @@ def run(config_path: str) -> None:
         logger.info("Running review agent")
 
         review = review_agent.review(architecture)
-        print("\n--- Review ---")
+        print("\n=== Review Report ===")
         print(review)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Generate banking architectures via LLM agents")
     parser.add_argument("config", help="Path to YAML configuration file")
+    parser.add_argument(
+        "requirements",
+        nargs="?",
+        default="requerimientos.txt",
+        help="Path to requirements file",
+    )
     args = parser.parse_args()
 
     configure_logging()
-    run(args.config)
+    run(args.config, args.requirements)
 
 if __name__ == "__main__":
     main()

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -42,6 +42,6 @@ def test_run_invokes_review(monkeypatch, capsys):
     open_orig = open
     monkeypatch.setattr("builtins.open", fake_open)
 
-    run("config.yaml")
+    run("config.yaml", "requerimiento.txt")
 
     assert call_order == ["arch", "review"]


### PR DESCRIPTION
## Summary
- permite indicar la ruta del archivo de requisitos al ejecutar `run`
- usa esa ruta para construir la lista `requirements`
- ajusta el mensaje de revisión a "=== Review Report ==="
- actualiza los tests para el nuevo argumento

## Testing
- `pip install pyyaml --quiet`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab4d0b0508327ad229a13d2f9c3b4