### PR TITLE
Add configurable token costs and improved logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,16 @@ for traceability.
    pip install openai PyYAML
    ```
 2. Create a configuration file (see `sample_config.yaml`). The file
-   lets you specify API keys and customize the prompts used by the
-  agents. Token usage and estimated cost are logged for each LLM request,
-  providing visibility into consumption.
+   lets you specify API keys, per-million token pricing and customize
+   the prompts used by the agents. Token usage and estimated cost are
+   logged for each LLM request, providing visibility into consumption.
 
-  Logging is configured at startup, producing messages such as:
-   `2025-07-06 14:12:03 [INFO] agentic_architect.llm_connectors: Tokens used - input: 150, output: 220, total: 370, cost: $0.0200`.
+   Logging is configured at startup, producing messages such as:
+   ```
+   2025-07-06 14:12:03 [INFO] agentic_architect.llm_connectors: Input tokens: 150, cost: $0.004500
+   2025-07-06 14:12:03 [INFO] agentic_architect.llm_connectors: Output tokens: 220, cost: $0.013200
+   2025-07-06 14:12:03 [INFO] agentic_architect.llm_connectors: Total tokens: 370, cost: $0.017700
+   ```
 
 3. Run the tool:
    ```bash

--- a/agentic_architect/config.py
+++ b/agentic_architect/config.py
@@ -1,12 +1,13 @@
 import yaml
 from dataclasses import dataclass, field
-from typing import Optional
+from typing import Optional, Dict
 
 @dataclass
 class LLMConfig:
     provider: str
     api_key: Optional[str] = None
     base_url: Optional[str] = None
+    costs: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -34,7 +35,13 @@ class Config:
         with open(path, 'r') as f:
             data = yaml.safe_load(f) or {}
 
-        llm = LLMConfig(**data.get('llm', {}))
+        llm_data = data.get('llm', {})
+        llm = LLMConfig(
+            provider=llm_data.get('provider'),
+            api_key=llm_data.get('api_key'),
+            base_url=llm_data.get('base_url'),
+            costs=llm_data.get('costs', {}),
+        )
         prompts = PromptConfig(**data.get('prompts', {}))
 
         return Config(

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -1,6 +1,9 @@
 llm:
   provider: gemini
   api_key: REMOVED_API_KEY
+  costs:
+    input: 0.03
+    output: 0.06
 review_enabled: true
 
 prompts:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -14,4 +14,6 @@ def test_usage_logging(caplog):
     prompts = PromptConfig()
     agent = ArchitectureAgent(connector, prompts)
     agent.generate_architecture(["requirement"])
-    assert any("Tokens used" in rec.message for rec in caplog.records)
+    assert any("Input tokens" in rec.message for rec in caplog.records)
+    assert any("Output tokens" in rec.message for rec in caplog.records)
+    assert any("Total tokens" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
- allow specifying token prices in the config file
- log input, output and total token costs separately
- update connectors to use configurable costs
- document new pricing config and example output
- adjust tests for new logging format

## Testing
- `pip install -q PyYAML`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686adf8b357c8327b6869676591dba67