### PR TITLE
Refine MarkdownAnalysisAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ for traceability.
   BIAN, TOGAF and coreless strategies.
 - **ReviewAgent** – optionally reviews the generated architecture for accuracy
   and completeness.
+- **MarkdownAnalysisAgent** – loads large Markdown documents and processes them
+  with chain-of-thought prompts.
 - Support for multiple LLM providers (OpenAI, Anthropic, Gemini, Ollama).
 - Simple CLI for providing requirements and configuration.
 
@@ -42,3 +44,20 @@ for traceability.
    ```
 
 The tool prints the proposed architecture and the review if enabled.
+
+To analyze a large Markdown document with your own prompt:
+
+```python
+from agentic_architect.agents.markdown_agent import MarkdownAnalysisAgent
+from agentic_architect.llm_connectors import OpenAIConnector
+
+connector = OpenAIConnector(api_key="YOUR_KEY")
+agent = MarkdownAnalysisAgent(connector)
+# analyze a file using chain-of-thought
+result = agent.analyze("Summarize the document", path="document.md")
+print(result)
+
+# you can also call the agent without a file
+reply = agent.analyze("What is the capital of France?")
+print(reply)
+```

--- a/agentic_architect/agents/markdown_agent.py
+++ b/agentic_architect/agents/markdown_agent.py
@@ -1,0 +1,57 @@
+import logging
+from typing import List
+
+from ..llm_connectors import LLMConnector
+
+logger = logging.getLogger(__name__)
+
+
+def _chunk_text(text: str, max_tokens: int = 2048) -> List[str]:
+    """Split text into chunks based on approximate token count."""
+    words = text.split()
+    chunks = []
+    for i in range(0, len(words), max_tokens):
+        chunk = " ".join(words[i : i + max_tokens])
+        chunks.append(chunk)
+    return chunks
+
+
+class MarkdownAnalysisAgent:
+    """Agent that analyzes large markdown files using chain-of-thought."""
+
+    def __init__(self, llm: LLMConnector):
+        self.llm = llm
+
+    def analyze(
+        self, user_prompt: str, path: str | None = None, *, max_tokens: int = 2048
+    ) -> str:
+        """Analyze a markdown file with the provided user prompt."""
+        if not path:
+            logger.info("No file provided, sending prompt directly")
+            return self.llm.generate(user_prompt)
+
+        logger.info("Loading markdown file from %s", path)
+        with open(path, "r") as f:
+            text = f.read()
+
+        chunks = _chunk_text(text, max_tokens=max_tokens)
+        logger.info("File split into %d chunks", len(chunks))
+
+        thoughts = []
+        for idx, chunk in enumerate(chunks, 1):
+            prompt = (
+                f"{user_prompt}\n\n"
+                f"### Chunk {idx}/{len(chunks)}\n"
+                f"{chunk}\n\n"
+                "Provide a short chain-of-thought analysis of this chunk."
+            )
+            logger.debug("Chunk %d prompt: %s", idx, prompt)
+            thoughts.append(self.llm.generate(prompt))
+
+        summary_prompt = "Combine the following analyses into a final answer:\n\n"
+        for i, thought in enumerate(thoughts, 1):
+            summary_prompt += f"Chunk {i} analysis:\n{thought}\n\n"
+        summary_prompt += "Provide the overall analysis."
+
+        logger.info("Generating final summary")
+        return self.llm.generate(summary_prompt)

--- a/tests/test_markdown_agent.py
+++ b/tests/test_markdown_agent.py
@@ -1,0 +1,35 @@
+from agentic_architect.agents.markdown_agent import MarkdownAnalysisAgent
+from agentic_architect.llm_connectors import LLMConnector
+
+
+class DummyConnector(LLMConnector):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+
+    def generate(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        return f"analysis{len(self.calls)}"
+
+
+def test_analyze_large_markdown(tmp_path):
+    text = "word " * 6000
+    path = tmp_path / "doc.md"
+    path.write_text(text)
+
+    connector = DummyConnector()
+    agent = MarkdownAnalysisAgent(connector)
+    result = agent.analyze("Summarize", path=str(path))
+
+    assert len(connector.calls) == 4  # 3 chunks + final summary
+    assert result == "analysis4"
+
+
+def test_analyze_prompt_only():
+    connector = DummyConnector()
+    agent = MarkdownAnalysisAgent(connector)
+
+    result = agent.analyze("Hello world")
+
+    assert connector.calls == ["Hello world"]
+    assert result == "analysis1"


### PR DESCRIPTION
## Summary
- make `MarkdownAnalysisAgent` handle prompts with or without a file
- demonstrate optional file usage in README
- test prompt-only path

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686ca98039a883279a1c1ae9ec430a96