### PR TITLE
Add document chain processing

### DIFF
--- a/agentic_architect/agents/document_chain.py
+++ b/agentic_architect/agents/document_chain.py
@@ -1,0 +1,65 @@
+import logging
+from typing import List
+
+from ..llm_connectors import LLMConnector
+
+logger = logging.getLogger(__name__)
+
+
+def chunk_text(text: str, min_tokens: int = 1000, max_tokens: int = 2000) -> List[str]:
+    """Split text into chunks between min_tokens and max_tokens tokens.
+
+    Tokens are approximated by whitespace-separated words. If the final chunk
+    would be smaller than ``min_tokens`` it is merged with the previous one.
+    """
+    if min_tokens > max_tokens:
+        raise ValueError("min_tokens cannot exceed max_tokens")
+
+    words = text.split()
+    chunks: List[List[str]] = []
+    start = 0
+    while start < len(words):
+        end = start + max_tokens
+        chunk = words[start:end]
+        if len(chunk) < min_tokens and chunks:
+            chunks[-1].extend(chunk)
+            break
+        chunks.append(chunk)
+        start = end
+    return [" ".join(c) for c in chunks]
+
+
+class DocumentChain:
+    """Process a document in manageable chunks and combine the results."""
+
+    def __init__(self, llm: LLMConnector, *, min_tokens: int = 1000, max_tokens: int = 2000) -> None:
+        self.llm = llm
+        self.min_tokens = min_tokens
+        self.max_tokens = max_tokens
+
+    def analyze(self, path: str) -> str:
+        """Analyze a Markdown document using a simple chain-of-thought pipeline."""
+        logger.info("Loading document %s", path)
+        with open(path, "r") as f:
+            text = f.read()
+
+        chunks = chunk_text(text, self.min_tokens, self.max_tokens)
+        logger.info("Document split into %d chunks", len(chunks))
+
+        summaries: List[str] = []
+        for idx, chunk in enumerate(chunks, 1):
+            prompt = (
+                "Read this section, extract the key steps, then await the next section.\n\n"
+                f"{chunk}"
+            )
+            logger.debug("Chunk %d prompt: %s", idx, prompt)
+            summaries.append(self.llm.generate(prompt))
+
+        final_prompt = (
+            "Here are all the chunk summaries—please integrate into a single coherent report.\n\n"
+        )
+        for i, summary in enumerate(summaries, 1):
+            final_prompt += f"Chunk {i} summary:\n{summary}\n\n"
+
+        logger.info("Generating final report from %d summaries", len(summaries))
+        return self.llm.generate(final_prompt)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the package root is on sys.path when running tests directly
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_document_chain.py
+++ b/tests/test_document_chain.py
@@ -1,0 +1,32 @@
+from agentic_architect.agents.document_chain import DocumentChain, chunk_text
+from agentic_architect.llm_connectors import LLMConnector
+
+class DummyConnector(LLMConnector):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+
+    def generate(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        return f"summary{len(self.calls)}"
+
+
+def test_chunk_text_merges_small_final_chunk():
+    text = "word " * 4500
+    chunks = chunk_text(text)
+    assert len(chunks) == 2
+    assert len(chunks[0].split()) == 2000
+    assert len(chunks[1].split()) == 2500
+
+
+def test_document_chain(tmp_path):
+    text = "word " * 4500
+    path = tmp_path / "doc.md"
+    path.write_text(text)
+
+    connector = DummyConnector()
+    chain = DocumentChain(connector)
+    result = chain.analyze(str(path))
+
+    assert len(connector.calls) == 3  # 2 chunks + final report
+    assert result == "summary3"


### PR DESCRIPTION
## Summary
- implement `DocumentChain` agent for chunk-based document processing
- provide `chunk_text` utility for 1000–2000 token slicing
- add tests for the new chain and a test helper to set up `PYTHONPATH`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb0b9144c832781b191a5e3151b43